### PR TITLE
Update contact-us and remove materials headers

### DIFF
--- a/_data/header_pages.yml
+++ b/_data/header_pages.yml
@@ -1,8 +1,8 @@
 - endpoint: about
   caption: about us
 - endpoint: schedule
-  caption: schedule
-- endpoint: materials
-  caption: materials
+  caption: workshops
 - endpoint: faq
   caption: faq
+- endpoint: contact
+  caption: contact us

--- a/_data/past_events.yml
+++ b/_data/past_events.yml
@@ -11,7 +11,7 @@
     <br>Please come prepared with a Linux environment installed (macOS or Windows Subsystem for Linux is NOT sufficient!). If you do not currently have one, we recommend installing Ubuntu in VirtualBox. Applications from the following Ubuntu packages will be used 
     <b>openssh-client mosh sshfs freerdp2-x11 gdb strace ltrace time linux-tools-common linux-tools-generic htop dstat iproute2 dnsutils traceroute tracepath</b>
     <br><a href='http://bit.ly/hs201906' target="_blank">Sign up here</a>
-  image: "static/img/linux.png"
+  image: "/static/img/linux.png"
   materials: >
     </strong><a class='calltoaction' href='https://nushackers.github.io/p-hackertools2/' target='_blank'>Materials here</a><br>
     </strong><a class='calltoaction' href='https://www.youtube.com/watch?v=FXM6e4fYgHs' target='_blank'>Video Recording here</a>
@@ -30,7 +30,7 @@
     using VirtualBox. (This workshop is inspired by <a href='https://hacker-tools.github.io/' target="_blank">hacker-tools class by SIPB at MIT</a>)<br>
     <a href="https://is.gd/hs2019_hackertools_1_material" target="_blank">Download the materials here</a><br>
     <a href='http://bit.ly/hs201905' target="_blank">Sign up here</a>
-  image: "static/img/linux_soldier.jpg"
+  image: "/static/img/linux_soldier.jpg"
   materials: >
     </strong><a class='calltoaction' href='https://is.gd/hs2019_hackertools_1_material' target='_blank'>Materials here.</a><br>
     </strong><a class='calltoaction' href='https://www.youtube.com/watch?v=mCbU82Ezdac' target='_blank'>Video Recording here</a>
@@ -44,7 +44,7 @@
     frontend engineering is done. We'll learn why it's special 
     and how to get started with it.
     <a href='http://bit.ly/hs201904' target="_blank">Sign up here</a> 
-  image: "static/img/react.png"
+  image: "/static/img/react.png"
   materials: "</strong><a class='calltoaction' href='https://www.dropbox.com/sh/6lg8fewj2mv53hp/AAAwX-br-EPc6q1TWZ4lZEKga?dl=0' target='_blank'>Materials here.</a><br></strong><a class='calltoaction' href=' https://codesandbox.io/s/n32lm45npl' target='_blank'>Completed project.</a>"
 
 - title: "Advanced JavaScript + Node.JS"
@@ -55,7 +55,7 @@
     This week, we will be covering advanced JavaScript topics and we will also 
     learn how JavaScript can be written on the server!
     <a href='http://bit.ly/hs201903' target="_blank">Sign up here</a> 
-  image: "static/img/node.png"
+  image: "/static/img/node.png"
   materials: "</strong><a class='calltoaction' href='http://bit.ly/hs-rscs' target='_blank'>Materials here.</a>"
 - title: "Introduction to JavaScript"
   datetime: Saturday, 23rd February 2019, 1:00pm - 4:00pm
@@ -68,7 +68,7 @@
     In the process, we'll go through the development of an interactive 
     web application. Remember to bring your own laptops!
     <a href='http://bit.ly/hs201902' target="_blank">Sign up here</a> 
-  image: "static/img/javascript.png"
+  image: "/static/img/javascript.png"
   materials: "</strong><a class='calltoaction' href='https://bit.ly/2TcPHwi' target='_blank'>Materials here.</a>"
 - title: "Introduction to HTML & CSS"
   datetime: Saturday, 16th February 2019, 1:00pm - 4:00pm

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -46,15 +46,6 @@
             {{ info.caption }}
           </a>
         {% endfor %}
-        <script language="javascript">
-          <!--
-          var part1 = "coreteam";
-          var part2 = "nushackers.org";
-          var part3 = "contact us";
-          document.write('<a href="mai' + 'lto:' + part1 + '@' + part2 + '?subject=hackerschool">');
-          document.write(part3 + '</a>');
-        // -->
-        </script>          
       </div>
     </header>
     {{ content }}

--- a/contact/index.html
+++ b/contact/index.html
@@ -1,0 +1,19 @@
+---
+layout: default
+---
+<section class='centered'>
+  <h2>Contact Us</h2>
+  <p>
+    If you want to get in touch with us, feel free to send us a message via our email 
+    <b><a href="mailto:coreteam@nushackers.org">coreteam@nushackers.org</a></b>.
+  </p>
+
+  <p>
+    This is ideal for things like: you’d like to request a workshop, you’d like to do a guest post on our site, you have further questions about our membership and organization.
+  </p>
+
+  <p>
+    If you want to give feedback on our workshops, you can again send a message to us via the email above. We also release feedback forms after every workshop
+    so that it is easy for you to give feedback and for us to collect it.
+  </p>
+</section>

--- a/faq/index.html
+++ b/faq/index.html
@@ -25,7 +25,7 @@ layout: default
             Do note, however, that available seats are handed out on a first-come-first-served basis, so there might not be any left by the time we start. Try to be early!
           </p>
           <p>
-            <span class="label">TL;DR:</span>a qualified yes.
+            <span class="label">TL;DR:</span> a qualified yes.
           </p>
         </div>
       </div>
@@ -48,7 +48,7 @@ layout: default
         <h3>I signed up for the workshop, but realize that I can't attend. Can I cancel?</h3>
         <div class="row">
           <p>
-            Yes! Just use the "contact us" link at the top of the page to drop us an email.
+            Yes! Just use the "contact us" link at the top of the page and drop us an email.
           </p>
         </div>
       </div>


### PR DESCRIPTION
Summary of changes:

1. Made the `contact us` header as a separate page. Previously it was not intuitive that to see that it is a link to the coreteam email.
2. Removed `materials` tab since it is not updated anymore.
3. Renamed the `schedule` tab to `workshops`, since it now contains video recordings and materials too.
4. Fixed minor problems.

Fix for https://github.com/nushackers/hackerschool/issues/21.