### PR TITLE
Add contact us link FAQ

### DIFF
--- a/faq/index.html
+++ b/faq/index.html
@@ -48,7 +48,7 @@ layout: default
         <h3>I signed up for the workshop, but realize that I can't attend. Can I cancel?</h3>
         <div class="row">
           <p>
-            Yes! Just use the "contact us" link at the top of the page and drop us an email.
+          Yes! Just use the <a href="/contact">contact us</a> link at the top of the page and drop us an email.
           </p>
         </div>
       </div>


### PR DESCRIPTION
The 'contact us' answer in the FAQ now has a link to the contact subpage.